### PR TITLE
Add npx prefix in case ember-cli isn’t installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To get this app on your computer,
 2. Clone this git repository: `git clone git@github.com:embermap/emberconf2019-robust-data-fetching.git`
 3. Move into the directory: `cd emberconf2019-robust-data-fetching`
 4. Run NPM install: `npm install` (You might get some warnings, thats ok!)
-5. Serve the app `ember s`
+5. Serve the app `npx ember s`
 6. Visit http://localhost:4200
 7. If you can see the screen below, you're all set!
 


### PR DESCRIPTION
Hey, I was following the preparation steps and having just installed the mentioned Node version, I didn’t have `ember-cli` installed, so the initial result was `zsh: command not found: ember` Not a big deal as I knew what to do, but I thought it might help to be explicit.

Another option would be to add an `npm install -g ember-cli` step, but this seems nicer?